### PR TITLE
Allow Tuya climate temperature_multiplier to be current/target multip…

### DIFF
--- a/esphome/components/tuya/climate/__init__.py
+++ b/esphome/components/tuya/climate/__init__.py
@@ -10,8 +10,42 @@ CODEOWNERS = ['@jesserockz']
 CONF_TARGET_TEMPERATURE_DATAPOINT = 'target_temperature_datapoint'
 CONF_CURRENT_TEMPERATURE_DATAPOINT = 'current_temperature_datapoint'
 CONF_TEMPERATURE_MULTIPLIER = 'temperature_multiplier'
+CONF_CURRENT_TEMPERATURE_MULTIPLIER = 'current_temperature_multiplier'
+CONF_TARGET_TEMPERATURE_MULTIPLIER = 'target_temperature_multiplier'
 
 TuyaClimate = tuya_ns.class_('TuyaClimate', climate.Climate, cg.Component)
+
+
+def validate_temperature_multipliers(value):
+    if CONF_TEMPERATURE_MULTIPLIER in value:
+        if (
+                CONF_CURRENT_TEMPERATURE_MULTIPLIER in value
+                or CONF_TARGET_TEMPERATURE_MULTIPLIER in value
+        ):
+            raise cv.Invalid((f"Cannot have {CONF_TEMPERATURE_MULTIPLIER} at the same time as "
+                              f"{CONF_CURRENT_TEMPERATURE_MULTIPLIER} and "
+                              f"{CONF_TARGET_TEMPERATURE_MULTIPLIER}"))
+    if (
+            CONF_CURRENT_TEMPERATURE_MULTIPLIER in value
+            and CONF_TARGET_TEMPERATURE_MULTIPLIER not in value
+    ):
+        raise cv.Invalid((f"{CONF_TARGET_TEMPERATURE_MULTIPLIER} required if using "
+                          f"{CONF_CURRENT_TEMPERATURE_MULTIPLIER}"))
+    if (
+            CONF_TARGET_TEMPERATURE_MULTIPLIER in value
+            and CONF_CURRENT_TEMPERATURE_MULTIPLIER not in value
+    ):
+        raise cv.Invalid((f"{CONF_CURRENT_TEMPERATURE_MULTIPLIER} required if using "
+                          f"{CONF_TARGET_TEMPERATURE_MULTIPLIER}"))
+    keys = (
+        CONF_TEMPERATURE_MULTIPLIER,
+        CONF_CURRENT_TEMPERATURE_MULTIPLIER,
+        CONF_TARGET_TEMPERATURE_MULTIPLIER
+    )
+    if all(multiplier not in value for multiplier in keys):
+        value[CONF_TEMPERATURE_MULTIPLIER] = 1.0
+    return value
+
 
 CONFIG_SCHEMA = cv.All(climate.CLIMATE_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(TuyaClimate),
@@ -19,9 +53,11 @@ CONFIG_SCHEMA = cv.All(climate.CLIMATE_SCHEMA.extend({
     cv.Optional(CONF_SWITCH_DATAPOINT): cv.uint8_t,
     cv.Optional(CONF_TARGET_TEMPERATURE_DATAPOINT): cv.uint8_t,
     cv.Optional(CONF_CURRENT_TEMPERATURE_DATAPOINT): cv.uint8_t,
-    cv.Optional(CONF_TEMPERATURE_MULTIPLIER, default=1): cv.positive_float,
+    cv.Optional(CONF_TEMPERATURE_MULTIPLIER): cv.positive_float,
+    cv.Optional(CONF_CURRENT_TEMPERATURE_MULTIPLIER): cv.positive_float,
+    cv.Optional(CONF_TARGET_TEMPERATURE_MULTIPLIER): cv.positive_float,
 }).extend(cv.COMPONENT_SCHEMA), cv.has_at_least_one_key(
-    CONF_TARGET_TEMPERATURE_DATAPOINT, CONF_SWITCH_DATAPOINT))
+    CONF_TARGET_TEMPERATURE_DATAPOINT, CONF_SWITCH_DATAPOINT), validate_temperature_multipliers)
 
 
 def to_code(config):
@@ -38,4 +74,9 @@ def to_code(config):
         cg.add(var.set_target_temperature_id(config[CONF_TARGET_TEMPERATURE_DATAPOINT]))
     if CONF_CURRENT_TEMPERATURE_DATAPOINT in config:
         cg.add(var.set_current_temperature_id(config[CONF_CURRENT_TEMPERATURE_DATAPOINT]))
-    cg.add(var.set_temperature_multiplier(config[CONF_TEMPERATURE_MULTIPLIER]))
+    if CONF_TEMPERATURE_MULTIPLIER in config:
+        cg.add(var.set_target_temperature_multiplier(config[CONF_TEMPERATURE_MULTIPLIER]))
+        cg.add(var.set_current_temperature_multiplier(config[CONF_TEMPERATURE_MULTIPLIER]))
+    else:
+        cg.add(var.set_current_temperature_multiplier(config[CONF_CURRENT_TEMPERATURE_MULTIPLIER]))
+        cg.add(var.set_target_temperature_multiplier(config[CONF_TARGET_TEMPERATURE_MULTIPLIER]))

--- a/esphome/components/tuya/climate/tuya_climate.cpp
+++ b/esphome/components/tuya/climate/tuya_climate.cpp
@@ -21,7 +21,7 @@ void TuyaClimate::setup() {
   }
   if (this->target_temperature_id_.has_value()) {
     this->parent_->register_listener(*this->target_temperature_id_, [this](TuyaDatapoint datapoint) {
-      this->target_temperature = datapoint.value_int * this->temperature_multiplier_;
+      this->target_temperature = datapoint.value_int * this->target_temperature_multiplier_;
       this->compute_state_();
       this->publish_state();
       ESP_LOGD(TAG, "MCU reported target temperature is: %.1f", this->target_temperature);
@@ -29,7 +29,7 @@ void TuyaClimate::setup() {
   }
   if (this->current_temperature_id_.has_value()) {
     this->parent_->register_listener(*this->current_temperature_id_, [this](TuyaDatapoint datapoint) {
-      this->current_temperature = datapoint.value_int * this->temperature_multiplier_;
+      this->current_temperature = datapoint.value_int * this->current_temperature_multiplier_;
       this->compute_state_();
       this->publish_state();
       ESP_LOGD(TAG, "MCU reported current temperature is: %.1f", this->current_temperature);
@@ -55,7 +55,7 @@ void TuyaClimate::control(const climate::ClimateCall &call) {
     TuyaDatapoint datapoint{};
     datapoint.id = *this->target_temperature_id_;
     datapoint.type = TuyaDatapointType::INTEGER;
-    datapoint.value_int = (int) (this->target_temperature / this->temperature_multiplier_);
+    datapoint.value_int = (int) (this->target_temperature / this->target_temperature_multiplier_);
     this->parent_->set_datapoint_value(datapoint);
     ESP_LOGD(TAG, "Setting target temperature: %.1f", this->target_temperature);
   }

--- a/esphome/components/tuya/climate/tuya_climate.h
+++ b/esphome/components/tuya/climate/tuya_climate.h
@@ -18,8 +18,11 @@ class TuyaClimate : public climate::Climate, public Component {
   void set_current_temperature_id(uint8_t current_temperature_id) {
     this->current_temperature_id_ = current_temperature_id;
   }
-  void set_temperature_multiplier(float temperature_multiplier) {
-    this->temperature_multiplier_ = temperature_multiplier;
+  void set_current_temperature_multiplier(float temperature_multiplier) {
+    this->current_temperature_multiplier_ = temperature_multiplier;
+  }
+  void set_target_temperature_multiplier(float temperature_multiplier) {
+    this->target_temperature_multiplier_ = temperature_multiplier;
   }
 
   void set_tuya_parent(Tuya *parent) { this->parent_ = parent; }
@@ -40,7 +43,8 @@ class TuyaClimate : public climate::Climate, public Component {
   optional<uint8_t> switch_id_{};
   optional<uint8_t> target_temperature_id_{};
   optional<uint8_t> current_temperature_id_{};
-  float temperature_multiplier_{1.0f};
+  float current_temperature_multiplier_{1.0f};
+  float target_temperature_multiplier_{1.0f};
 };
 
 }  // namespace tuya

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -92,7 +92,8 @@ climate:
     id: tuya_climate
     switch_datapoint: 1
     target_temperature_datapoint: 3
-    temperature_multiplier: 0.5
+    current_temperature_multiplier: 0.5
+    target_temperature_multiplier: 0.5
 
 switch:
   - platform: tuya


### PR DESCRIPTION
…lier (#1345)

* Separate temperature_multiplier to current/target multiplier

* Apply suggestions from code review

Co-authored-by: Jesse Hills <3060199+jesserockz@users.noreply.github.com>

Co-authored-by: Jesse Hills <3060199+jesserockz@users.noreply.github.com>

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
