### PR TITLE
feat: Make code templatable for Midea (IR)

### DIFF
--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -1308,10 +1308,10 @@ MideaData, MideaBinarySensor, MideaTrigger, MideaAction, MideaDumper = declare_p
 MideaAction = ns.class_("MideaAction", RemoteTransmitterActionBase)
 MIDEA_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_CODE): cv.All(
+        cv.Required(CONF_CODE): cv.templatable(cv.All(
             [cv.Any(cv.hex_uint8_t, cv.uint8_t)],
             cv.Length(min=5, max=5),
-        ),
+        )),
     }
 )
 
@@ -1337,7 +1337,12 @@ def midea_dumper(var, config):
     MIDEA_SCHEMA,
 )
 async def midea_action(var, config, args):
-    cg.add(var.set_code(config[CONF_CODE]))
+    code_ = config[CONF_CODE]
+    if cg.is_template(code_):
+        template_ = await cg.templatable(code_, args, cg.std_vector.template(cg.uint8))
+        cg.add(var.set_code_template(template_))
+    else:
+        cg.add(var.set_code_static(code_))
 
 
 # AEHA

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -1308,10 +1308,12 @@ MideaData, MideaBinarySensor, MideaTrigger, MideaAction, MideaDumper = declare_p
 MideaAction = ns.class_("MideaAction", RemoteTransmitterActionBase)
 MIDEA_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_CODE): cv.templatable(cv.All(
-            [cv.Any(cv.hex_uint8_t, cv.uint8_t)],
-            cv.Length(min=5, max=5),
-        )),
+        cv.Required(CONF_CODE): cv.templatable(
+            cv.All(
+                [cv.Any(cv.hex_uint8_t, cv.uint8_t)],
+                cv.Length(min=5, max=5),
+            )
+        ),
     }
 )
 

--- a/esphome/components/remote_base/midea_protocol.h
+++ b/esphome/components/remote_base/midea_protocol.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <array>
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "remote_base.h"
+#include <array>
+#include <utility>
 
 namespace esphome {
 namespace remote_base {
@@ -84,24 +85,23 @@ using MideaDumper = RemoteReceiverDumper<MideaProtocol, MideaData>;
 
 template<typename... Ts> class MideaAction : public RemoteTransmitterActionBase<Ts...> {
   TEMPLATABLE_VALUE(std::vector<uint8_t>, code)
-  void set_code_static(std::vector<uint8_t> code) { code_static_ = code; }
+  void set_code_static(std::vector<uint8_t> code) { code_static_ = std::move(code); }
   void set_code_template(std::function<std::vector<uint8_t>(Ts...)> func) { this->code_func_ = func; }
-  
+
   void encode(RemoteTransmitData *dst, Ts... x) override {
     MideaData data;
     if (!this->code_static_.empty()) {
       data = MideaData(this->code_static_);
-    }
-    else {
+    } else {
       data = MideaData(this->code_func_(x...));
     }
     data.finalize();
     MideaProtocol().encode(dst, data);
   }
 
-  protected:
-    std::function<std::vector<uint8_t>(Ts...)> code_func_{};
-    std::vector<uint8_t> code_static_{};
+protected:
+  std::function<std::vector<uint8_t>(Ts...)> code_func_{};
+  std::vector<uint8_t> code_static_{};
 };
 
 }  // namespace remote_base

--- a/esphome/components/remote_base/midea_protocol.h
+++ b/esphome/components/remote_base/midea_protocol.h
@@ -99,7 +99,7 @@ template<typename... Ts> class MideaAction : public RemoteTransmitterActionBase<
     MideaProtocol().encode(dst, data);
   }
 
-protected:
+ protected:
   std::function<std::vector<uint8_t>(Ts...)> code_func_{};
   std::vector<uint8_t> code_static_{};
 };


### PR DESCRIPTION
# What does this implement/fix?
This change on the Midea IR component makes the _code_ property templatable which, by example, allows to send follow me commands without having to connect the ESPHome device to the Midea AC.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <[Add midea_ir.follow_me action #1627](https://github.com/esphome/feature-requests/issues/1627)>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
remote_transmitter:
  id: ir
  pin: GPIO13  
  carrier_duty_percent: 50% 
 
climate:
  - platform: midea_ir
    sensor: temp
    name: "AC"

sensor:
  - platform: homeassistant
    id: temp
    name: "Temperature Sensor From Home Assistant"
    entity_id: sensor.salon_current_temperature
   
interval:
  - interval: 10s
    then:
      - remote_transmitter.transmit_midea:
          code: !lambda |-
            return {0xA4, 0x82, 0x48, 0x7F, (uint8_t)(id(temp).state + 1)};
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
